### PR TITLE
fix(ci): remove unsupported python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10, 3.11 ]
+        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" ]
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [ 3.7, 3.8, 3.9, 3.10, 3.11 ]
 
     steps:
       - name: Checkout repository

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,5 @@ dmypy.json
 
 # vscode
 .vscode/
+
+.idea/


### PR DESCRIPTION
### Description

The poetry installer is not able to install poetry on python 3.6 anymore. python 3.6 is end of live. removed python 3.6 from the build matrix, added 3.10 and 3.11

### Links

<!--
Replace this comment block with relevant links to project trackers,
like Jira, RPD or GitHub here. Example:

* Fixes #1
* Fixes #2
-->

### Testing

<!--
Replace this comment block with any testing instructions for reviewers. This is in
addition to any acceptance criteria in an associated issue.
-->

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
