### PR TITLE
chore(workflow): check title length if not dependabot

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   check-title:
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' }}
     name: Check title
     runs-on: ubuntu-20.04
 


### PR DESCRIPTION
### Description

Adds a check to see if the user creating the PR is `dependabot`, if so, then the `pr-checks` do not run. This is to prevent the annoying failing checks for when the PR title exceeds the maximum length defined in `pr-checks`, which is typical for dependabot PRs.

### Testing

Did the tests on [this PR](https://github.com/factset/enterprise-sdk-utils-java/pull/106).

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
