### PR TITLE
fix: race-condition on token request close to expiry

### DIFF
--- a/src/fds/sdk/utils/authentication/confidential.py
+++ b/src/fds/sdk/utils/authentication/confidential.py
@@ -242,7 +242,7 @@ class ConfidentialClient(OAuth2Client):
         if not self._cached_token:
             log.debug("Access Token cache is empty")
             return False
-        if time.time() < self._cached_token[CONSTS.TOKEN_EXPIRES_AT] - 30:
+        if time.time() < self._cached_token[CONSTS.TOKEN_EXPIRES_AT] - CONSTS.TOKEN_EXPIRY_OFFSET_SECS:
             return True
         else:
             log.debug("Cached access token has expired at %s", self._cached_token[CONSTS.TOKEN_EXPIRES_AT])

--- a/src/fds/sdk/utils/authentication/confidential.py
+++ b/src/fds/sdk/utils/authentication/confidential.py
@@ -242,7 +242,7 @@ class ConfidentialClient(OAuth2Client):
         if not self._cached_token:
             log.debug("Access Token cache is empty")
             return False
-        if time.time() < self._cached_token[CONSTS.TOKEN_EXPIRES_AT]:
+        if time.time() < self._cached_token[CONSTS.TOKEN_EXPIRES_AT] - 30:
             return True
         else:
             log.debug("Cached access token has expired at %s", self._cached_token[CONSTS.TOKEN_EXPIRES_AT])

--- a/src/fds/sdk/utils/authentication/constants.py
+++ b/src/fds/sdk/utils/authentication/constants.py
@@ -14,6 +14,7 @@ class CONSTS:
     # access token
     TOKEN_ACCESS_TOKEN = "access_token"
     TOKEN_EXPIRES_AT = "expires_at"
+    TOKEN_EXPIRY_OFFSET_SECS = 30
 
     # config
     CONFIG_CLIENT_ID = "clientId"

--- a/tests/fds/sdk/utils/authentication/test_confidential.py
+++ b/tests/fds/sdk/utils/authentication/test_confidential.py
@@ -409,7 +409,7 @@ def test_get_access_token_cached(example_config, mocker, caplog):
     mock_oauth2_session = mocker.patch("fds.sdk.utils.authentication.confidential.OAuth2Session")
     mock_oauth2_session.return_value.fetch_token.return_value = {
         "access_token": "test",
-        "expires_at": 10,
+        "expires_at": 40,
     }
     mocker.patch("fds.sdk.utils.authentication.confidential.time.time", return_value=0)
 
@@ -418,7 +418,7 @@ def test_get_access_token_cached(example_config, mocker, caplog):
     assert client.get_access_token() == client.get_access_token()
     mock_oauth2_session.return_value.fetch_token.assert_called_once()
 
-    assert "Retrieving cached token. Expires in '10' seconds" in caplog.text
+    assert "Retrieving cached token. Expires in '40' seconds" in caplog.text
 
 
 def test_get_access_token_cache_expired(client, mocker, caplog):
@@ -428,7 +428,7 @@ def test_get_access_token_cache_expired(client, mocker, caplog):
         "fds.sdk.utils.authentication.confidential.OAuth2Session.fetch_token",
         return_value={
             "access_token": "test",
-            "expires_at": 10,
+            "expires_at": 30,
         },
     )
 


### PR DESCRIPTION
### Description

Fix a race condition, when a request is almost exactly when the token is about to expire.

### Links

### Testing

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
