### PR TITLE
fix(publish): bump Python to 3.12 and miniconda to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ jobs:
     name: Deploy to package index
     runs-on: ubuntu-24.04
     env:
-      PYTHON_VERSION: 3.9
+      PYTHON_VERSION: "3.12"
       REPOSITORY_USERNAME: ${{ secrets.PYPI_USERNAME }}
       REPOSITORY_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       REPOSITORY_URL: ${{ secrets.PYPI_PUBLISH_URL }}
@@ -26,7 +26,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           miniconda-version: "latest"
           activate-environment: ${{ env.CONDA_ENV_NAME }}
@@ -64,7 +64,7 @@ jobs:
           while [ $count -lt $max_retries ]; do
             # Create meta.yaml recipe for the package pulled from PyPi
             grayskull pypi fds.sdk.utils==${version}
-            
+
             if [ -f ./fds.sdk.utils/meta.yaml ]; then
               echo "Version ${version} of fds.sdk.utils is available on PyPI."
 
@@ -85,7 +85,7 @@ jobs:
               conda config --set anaconda_upload no
               package_file=$(conda build fds.sdk.utils --output)
               conda build -c conda-forge fds.sdk.utils
-              
+
               anaconda -t $ANACONDA_TOKEN upload -u factset -l main ${package_file}
               break
             else


### PR DESCRIPTION
### Description

- `PYTHON_VERSION`: `3.9` → `3.12` — Poetry 2.x (latest) requires Python 3.10+, causing install failure on 3.9
- `setup-miniconda`: `v3` → `v4` — v3 runs on Node.js 20 which is deprecated on GitHub Actions runners - forced removal September 16, 2026

No changes to package code or published artifacts.

<!--
Replace this comment block with detailed description detailed description
of **what** is being changed and **why**.

Here's an example of a good change description:

Added the ability to notify users when a new blog post is made
so that users can be made aware of new features as they become
available.

Used the subscription module to allow users to subscribe to
the various product categories that they are interested in. Emails
are being sent using the smtp module, configured to use FactSet's
standard smtp server.
-->

### Links

<!--
Replace this comment block with relevant links to project trackers,
like Jira, RPD or GitHub here. Example:

* Fixes #1
* Fixes #2
-->

### Testing

<!--
Replace this comment block with any testing instructions for reviewers. This is in
addition to any acceptance criteria in an associated issue.
-->

### Checklist

Ensure the following things have been met before requesting a review:

* [x] Follows all project developer guide and coding standards.
* [x] Tests have been written for the change, when applicable.
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
