### PR TITLE
refactor(publish): split the workflow in multiple jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Deploy to package index
@@ -12,8 +15,6 @@ jobs:
       PYTHON_VERSION: "3.10"
       UV_PUBLISH_TOKEN: ${{ secrets.PYPI_PASSWORD }}
       REPOSITORY_URL: ${{ secrets.PYPI_PUBLISH_URL }}
-      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-      CONDA_ENV_NAME: conda-env
 
     steps:
       - name: Checkout repository
@@ -29,13 +30,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Setup Conda
-        uses: conda-incubator/setup-miniconda@v4
-        with:
-          miniconda-version: "latest"
-          activate-environment: ${{ env.CONDA_ENV_NAME }}
-          python-version: ${{ env.PYTHON_VERSION }}
-
       - name: Build
         run: |
           uv build
@@ -43,6 +37,27 @@ jobs:
       - name: Publish
         run: |
           uv publish
+
+  publish-conda:
+    name: Publish to Anaconda
+    needs: deploy
+    if: ${{ !github.event.release.prerelease }}
+    runs-on: ubuntu-24.04
+    env:
+      PYTHON_VERSION: "3.10"
+      ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+      CONDA_ENV_NAME: conda-env
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Conda
+        uses: conda-incubator/setup-miniconda@v4
+        with:
+          miniconda-version: "latest"
+          activate-environment: ${{ env.CONDA_ENV_NAME }}
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Publish to Anaconda
         shell: bash -el {0}


### PR DESCRIPTION
### Description

Split the `publish.yml` `deploy` job into two jobs — `deploy` (PyPI) and `publish-conda` (Anaconda) — so that pre-release (beta) versions can be published to PyPI without also being pushed to Anaconda's `main` label.

Previously, every published GitHub release (including pre-releases) ran the same job, which always uploaded to Anaconda's `main` label — the label a plain `conda install fds.sdk.utils` resolves to. That's fine for stable releases, but a beta version has no business being handed to every conda user with no opt-in, unlike PyPI where pre-release versions are already excluded by default (`pip install --pre` or an exact `==` pin is required to get one).

Changes:
* `publish-conda` is a separate job with `needs: deploy` and `if: ${{ !github.event.release.prerelease }}`, so it's skipped entirely when the triggering release is marked as a pre-release.
* `deploy` now only builds and publishes to PyPI (`uv build` / `uv publish`); the Anaconda-only env vars (`ANACONDA_TOKEN`, `CONDA_ENV_NAME`) and the "Setup Conda" / "Publish to Anaconda" steps moved to `publish-conda`, which checks out the repo again since jobs run on independent runners.
* Added an explicit `permissions: contents: read` at the workflow level — neither job needs more than that (checkout only; PyPI/Anaconda publishing use their own secrets, not `GITHUB_TOKEN`), so this pins it down instead of relying on the org/repo default.

To publish a beta going forward: bump `version` in `pyproject.toml` to a PEP 440 pre-release (e.g. `3.1.0b1`), tag it (e.g. `v3.1.0b1`), and create a GitHub Release with "Set as a pre-release" checked.

### Links

N/A

### Testing

* This workflow only runs on an actual GitHub release publish event, so it can't be exercised locally — verification is a real pre-release and a real stable release once merged.

### Checklist

* [x] Follows all project developer guide and coding standards.
* [ ] Tests have been written for the change, when applicable. *(N/A — GitHub Actions workflow, no unit test coverage applies)*
* [x] Confidential information (credentials, auth tokens, etc...) is not included.
